### PR TITLE
Fix bug in crossSection_plugin

### DIFF
--- a/lasagna_helperFunctions.py
+++ b/lasagna_helperFunctions.py
@@ -35,6 +35,10 @@ def findPyQtGraphObjectNameInPlotWidget(PlotWidget,itemName,regex=False):
     if regex==True:
         import re
 
+    if not hasattr(PlotWidget, 'getPlotItem'):
+        print "findPyQtGraphObjectNameInPlotWidget finds no attribute getPlotItem"
+        return False
+
     pltItem = PlotWidget.getPlotItem()
 
     if not hasattr(pltItem,'items'):

--- a/tutorialPlugins/crossSection_plugin.py
+++ b/tutorialPlugins/crossSection_plugin.py
@@ -55,7 +55,7 @@ class plugin(lasagna_plugin, QtGui.QWidget, cross_section_plot_UI.Ui_xSection): 
 
         #Extract data from base image
         if ImageItem != None:
-            if ImageItem.image.shape[1]<=Y:
+            if ImageItem.image.shape[1]<=Y or Y<0:
                 return
             xData = ImageItem.image[:,Y]
 


### PR DESCRIPTION
crossSection was failing if the mouse is above the first plane in the bottom
left panel (XZ plot). Check if Y is negative and return if it is fixed that.

crossSection also failed when the mouse was in the right bottom panel (empty
panel right of the XZ plot and below the YZ plot). Add a hasattr check in
lasagna_helperFunctions fixed that. Now it prints a warning.