### PR TITLE
numpy v1.24 compatibility fix

### DIFF
--- a/lasagna/lasagna_viewBox.py
+++ b/lasagna/lasagna_viewBox.py
@@ -145,7 +145,7 @@ class lasagna_viewBox(pg.ViewBox):
             self.progressLayer.emit()
         else:
             # Handle zoom (mousewheel with no keyboard modifier)
-            mask = np.array(self.state["mouseEnabled"], dtype=np.float)
+            mask = np.array(self.state["mouseEnabled"], dtype=float)
 
             if axis is not None and 0 <= axis < len(mask):
                 mv = mask[axis]


### PR DESCRIPTION
numpy has deprecated numpy.float amongst other changes. This simple edit corrects the incompatibility.